### PR TITLE
feat(pdf): add monthly matrix layout with general info header and adaptive widths

### DIFF
--- a/src/features/inspection/screens/FormScreen.tsx
+++ b/src/features/inspection/screens/FormScreen.tsx
@@ -1,34 +1,109 @@
 import { useEffect, useState } from "react";
-import { Text, StyleSheet, ScrollView, Pressable } from "react-native";
+import { Text, StyleSheet, ScrollView, Pressable, TextInput, View } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
 import Screen from "@shared/components/Screen";
 import Button from "@shared/components/Button";
-import BoolField from "../components/BoolField";
-import KmInput from "../components/KmInput";
-import { getByDate } from "../services/inspectionStorage";
-import { upsertInspection } from "../usecases/upsertEntry";
-import { todayLocalISO } from "@shared/utils/date";
+import BoolField from "@features/inspection/components/BoolField";
+import KmInput from "@features/inspection/components/KmInput";
+import { getByDate } from "@features/inspection/services/inspectionStorage";
+import { upsertInspection } from "@features/inspection/usecases/upsertEntry";
+import { monthLocalISO, toLocalISO } from "@shared/utils/date";
 
 export default function FormScreen() {
   const params = useLocalSearchParams<{ date?: string }>();
-  const date = params.date ?? todayLocalISO();
+  const date = params.date ? String(params.date) : toLocalISO(new Date());
+  const month = monthLocalISO(new Date(date as string)); // YYYY-MM local
 
   const [loading, setLoading] = useState(true);
+
+  // --- Información general ---
+  const [movil, setMovil] = useState("");
+  const [placas, setPlacas] = useState("");
+  const [conductorNombre, setConductorNombre] = useState("");
+
+  // --- (lo que ya tenías) Interior Vehículo ---
   const [pitoReversa, setPitoReversa] = useState(false);
   const [timon, setTimon] = useState(false);
   const [cinturon, setCinturon] = useState(false);
   const [martillos, setMartillos] = useState(false);
   const [kilometraje, setKilometraje] = useState("");
 
+  // --- Antes de la operación ---
+  // Llantas
+  const [llantasPresion, setLlantasPresion] = useState(false);
+  const [llantasObjetos, setLlantasObjetos] = useState(false);
+  const [llantasTuercas, setLlantasTuercas] = useState(false);
+  // Fugas
+  const [fugasMotor, setFugasMotor] = useState(false);
+  const [fugasCaja, setFugasCaja] = useState(false);
+  const [fugasDiferencial, setFugasDiferencial] = useState(false);
+  const [fugasCombustible, setFugasCombustible] = useState(false);
+  // Niveles y tapas
+  const [nivelMotor, setNivelMotor] = useState(false);
+  const [nivelRefrigerante, setNivelRefrigerante] = useState(false);
+  const [nivelHidraulico, setNivelHidraulico] = useState(false);
+  const [nivelFrenosEmbrague, setNivelFrenosEmbrague] = useState(false);
+  // Filtros
+  const [filtrosEstado, setFiltrosEstado] = useState(false);
+  const [filtrosFugas, setFiltrosFugas] = useState(false);
+  // Baterías
+  const [bateriasBornes, setBateriasBornes] = useState(false);
+  const [bateriasEstado, setBateriasEstado] = useState(false);
+  // Correas
+  const [correasEstado, setCorreasEstado] = useState(false);
+  const [correasTension, setCorreasTension] = useState(false);
+  // Revisión interna
+  const [revAseo, setRevAseo] = useState(false);
+  const [revLucesAltas, setRevLucesAltas] = useState(false);
+  const [revLucesBajas, setRevLucesBajas] = useState(false);
+  const [revCocuyos, setRevCocuyos] = useState(false);
+  const [revLuzBlanca, setRevLuzBlanca] = useState(false);
+
   useEffect(() => {
     (async () => {
       const existing = await getByDate(date);
       if (existing) {
+        // General
+        setMovil(existing.movil ?? "");
+        setPlacas(existing.placas ?? "");
+        setConductorNombre(existing.conductorNombre ?? "");
+
+        // Interior
         setPitoReversa(existing.pitoReversa);
         setTimon(existing.timon);
         setCinturon(existing.cinturones);
         setMartillos(existing.martillos);
         setKilometraje(String(existing.kilometraje));
+
+        // Llantas
+        setLlantasPresion(!!existing.llantasPresion);
+        setLlantasObjetos(!!existing.llantasObjetos);
+        setLlantasTuercas(!!existing.llantasTuercas);
+        // Fugas
+        setFugasMotor(!!existing.fugasMotor);
+        setFugasCaja(!!existing.fugasCaja);
+        setFugasDiferencial(!!existing.fugasDiferencial);
+        setFugasCombustible(!!existing.fugasCombustible);
+        // Niveles
+        setNivelMotor(!!existing.nivelMotor);
+        setNivelRefrigerante(!!existing.nivelRefrigerante);
+        setNivelHidraulico(!!existing.nivelHidraulico);
+        setNivelFrenosEmbrague(!!existing.nivelFrenosEmbrague);
+        // Filtros
+        setFiltrosEstado(!!existing.filtrosEstado);
+        setFiltrosFugas(!!existing.filtrosFugas);
+        // Baterías
+        setBateriasBornes(!!existing.bateriasBornes);
+        setBateriasEstado(!!existing.bateriasEstado);
+        // Correas
+        setCorreasEstado(!!existing.correasEstado);
+        setCorreasTension(!!existing.correasTension);
+        // Revisión interna
+        setRevAseo(!!existing.revAseo);
+        setRevLucesAltas(!!existing.revLucesAltas);
+        setRevLucesBajas(!!existing.revLucesBajas);
+        setRevCocuyos(!!existing.revCocuyos);
+        setRevLuzBlanca(!!existing.revLuzBlanca);
       }
       setLoading(false);
     })();
@@ -40,9 +115,32 @@ export default function FormScreen() {
       alert("Ingresa un kilometraje válido.");
       return;
     }
+
     await upsertInspection(date, {
+      month, // <- se guarda mes local YYYY-MM
+
+      // General
+      movil, placas, conductorNombre,
+
+      // Interior existente
       pitoReversa, timon, cinturones: cinturon, martillos, kilometraje: kmNum,
+
+      // Llantas
+      llantasPresion, llantasObjetos, llantasTuercas,
+      // Fugas
+      fugasMotor, fugasCaja, fugasDiferencial, fugasCombustible,
+      // Niveles
+      nivelMotor, nivelRefrigerante, nivelHidraulico, nivelFrenosEmbrague,
+      // Filtros
+      filtrosEstado, filtrosFugas,
+      // Baterías
+      bateriasBornes, bateriasEstado,
+      // Correas
+      correasEstado, correasTension,
+      // Revisión interna
+      revAseo, revLucesAltas, revLucesBajas, revCocuyos, revLuzBlanca,
     });
+
     router.replace("/"); // volver a inicio
   };
 
@@ -51,23 +149,100 @@ export default function FormScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Formulario del día</Text>
-      <Text style={styles.subtitle}>{date}</Text>
+      <Text style={styles.subtitle}>{toLocalISO(new Date(date))}</Text>
 
+      {/* Información general */}
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Información general</Text>
+
+        <LabeledInput label="Mes" value={month} editable={false} />
+        <LabeledInput label="Móvil" value={movil} onChangeText={setMovil} />
+        <LabeledInput label="Placas" value={placas} onChangeText={setPlacas} autoCapitalize="characters" />
+        <LabeledInput label="Nombre del conductor" value={conductorNombre} onChangeText={setConductorNombre} />
+      </View>
+
+      {/* Interior vehículo (lo previo) */}
       <Pressable style={styles.card}>
-        <Text style={styles.sectionTitle}>Interior Vehiculo</Text>
-
+        <Text style={styles.sectionTitle}>Interior Vehículo</Text>
         <BoolField label="Pito reversa" value={pitoReversa} onChange={setPitoReversa} />
         <BoolField label="Timón" value={timon} onChange={setTimon} />
         <BoolField label="Cinturón en cada puesto" value={cinturon} onChange={setCinturon} />
         <BoolField label="Presencia de martillos" value={martillos} onChange={setMartillos} />
-
         <KmInput value={kilometraje} onChange={setKilometraje} />
-
-        <Button title="Guardar" onPress={handleGuardar} />
       </Pressable>
 
+      {/* Antes de la operación */}
+      <Pressable style={styles.card}>
+        <Text style={styles.sectionTitle}>Antes de la operación</Text>
+
+        <Text style={styles.groupTitle}>Llantas</Text>
+        <BoolField label="Presión de aire" value={llantasPresion} onChange={setLlantasPresion} />
+        <BoolField label="Objetos incrustados" value={llantasObjetos} onChange={setLlantasObjetos} />
+        <BoolField label="Estado de tuercas (completas y ajustadas)" value={llantasTuercas} onChange={setLlantasTuercas} />
+
+        <Text style={styles.groupTitle}>Fugas</Text>
+        <BoolField label="Motor" value={fugasMotor} onChange={setFugasMotor} />
+        <BoolField label="Caja" value={fugasCaja} onChange={setFugasCaja} />
+        <BoolField label="Diferencial" value={fugasDiferencial} onChange={setFugasDiferencial} />
+        <BoolField label="Combustible" value={fugasCombustible} onChange={setFugasCombustible} />
+
+        <Text style={styles.groupTitle}>Niveles y tapas</Text>
+        <BoolField label="Motor" value={nivelMotor} onChange={setNivelMotor} />
+        <BoolField label="Agua o refrigerante" value={nivelRefrigerante} onChange={setNivelRefrigerante} />
+        <BoolField label="Hidráulico" value={nivelHidraulico} onChange={setNivelHidraulico} />
+        <BoolField label="Líquido de frenos o embrague" value={nivelFrenosEmbrague} onChange={setNivelFrenosEmbrague} />
+
+        <Text style={styles.groupTitle}>Filtros</Text>
+        <BoolField label="Estado" value={filtrosEstado} onChange={setFiltrosEstado} />
+        <BoolField label="Fugas" value={filtrosFugas} onChange={setFiltrosFugas} />
+
+        <Text style={styles.groupTitle}>Baterías</Text>
+        <BoolField label="Bornes" value={bateriasBornes} onChange={setBateriasBornes} />
+        <BoolField label="Estado general" value={bateriasEstado} onChange={setBateriasEstado} />
+
+        <Text style={styles.groupTitle}>Correas</Text>
+        <BoolField label="Estado" value={correasEstado} onChange={setCorreasEstado} />
+        <BoolField label="Tensión" value={correasTension} onChange={setCorreasTension} />
+
+        <Text style={styles.groupTitle}>Revisión interna</Text>
+        <BoolField label="Aseo" value={revAseo} onChange={setRevAseo} />
+        <BoolField label="Luces altas" value={revLucesAltas} onChange={setRevLucesAltas} />
+        <BoolField label="Luces bajas" value={revLucesBajas} onChange={setRevLucesBajas} />
+        <BoolField label="Cocuyos" value={revCocuyos} onChange={setRevCocuyos} />
+        <BoolField label="Luz blanca" value={revLuzBlanca} onChange={setRevLuzBlanca} />
+      </Pressable>
+
+      <Button title="Guardar" onPress={handleGuardar} />
       <Button title="← Regresar" onPress={() => router.back()} variant="secondary" />
     </ScrollView>
+  );
+}
+
+/** Input simple con etiqueta (evita crear archivo nuevo por ahora) */
+function LabeledInput({
+  label,
+  value,
+  onChangeText,
+  editable = true,
+  autoCapitalize,
+}: {
+  label: string;
+  value: string;
+  onChangeText?: (t: string) => void;
+  editable?: boolean;
+  autoCapitalize?: "none" | "sentences" | "words" | "characters";
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput
+        style={[styles.input, !editable && { backgroundColor: "#f3f4f6", color: "#6b7280" }]}
+        value={value}
+        onChangeText={onChangeText}
+        editable={editable}
+        autoCapitalize={autoCapitalize}
+      />
+    </View>
   );
 }
 
@@ -75,6 +250,21 @@ const styles = StyleSheet.create({
   container: { padding: 24, gap: 12 },
   title: { fontSize: 22, fontWeight: "700" },
   subtitle: { fontSize: 16, color: "#4b5563" },
+
   card: { marginTop: 12, padding: 16, backgroundColor: "#f3f4f6", borderRadius: 12, gap: 12 },
   sectionTitle: { fontSize: 18, fontWeight: "700", marginBottom: 4 },
+  groupTitle: { fontSize: 16, fontWeight: "700", marginTop: 8 },
+
+  row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 12 },
+  label: { fontSize: 16, flex: 1 },
+  input: {
+    flexBasis: 180,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: "#fff",
+    borderColor: "#e5e7eb",
+    borderWidth: 1,
+    fontSize: 16,
+  },
 });

--- a/src/features/inspection/types/InspectionEntry.ts
+++ b/src/features/inspection/types/InspectionEntry.ts
@@ -1,11 +1,57 @@
 export type InspectionEntry = {
   id: string;
-  date: string;          // YYYY-MM-DD (único por día)
+  date: string;      // YYYY-MM-DD (único por día)
+  month: string;     // YYYY-MM (autocompletado desde la fecha)
+
+  // Información general / usuario
+  movil?: string;
+  placas?: string;
+  conductorNombre?: string;
+
+  // (Lo que ya tenías)
   pitoReversa: boolean;
   timon: boolean;
   cinturones: boolean;
   martillos: boolean;
   kilometraje: number;
+
+  // --- Antes de la operación ---
+  // Llantas
+  llantasPresion: boolean;
+  llantasObjetos: boolean;
+  llantasTuercas: boolean;
+
+  // Fugas
+  fugasMotor: boolean;
+  fugasCaja: boolean;
+  fugasDiferencial: boolean;
+  fugasCombustible: boolean;
+
+  // Niveles y tapas
+  nivelMotor: boolean;
+  nivelRefrigerante: boolean;
+  nivelHidraulico: boolean;
+  nivelFrenosEmbrague: boolean;
+
+  // Filtros
+  filtrosEstado: boolean;
+  filtrosFugas: boolean;
+
+  // Baterías
+  bateriasBornes: boolean;
+  bateriasEstado: boolean;
+
+  // Correas
+  correasEstado: boolean;
+  correasTension: boolean;
+
+  // Revisión interna
+  revAseo: boolean;
+  revLucesAltas: boolean;
+  revLucesBajas: boolean;
+  revCocuyos: boolean;
+  revLuzBlanca: boolean;
+
   createdAt: number;
   updatedAt?: number;
 };

--- a/src/features/inspection/usecases/upsertEntry.ts
+++ b/src/features/inspection/usecases/upsertEntry.ts
@@ -5,22 +5,65 @@ function uid() {
   return Math.random().toString(36).slice(2, 10);
 }
 
-export async function upsertInspection(
-  date: string,
-  data: Omit<InspectionEntry, "id" | "date" | "createdAt" | "updatedAt">
-) {
+export type InspectionDataInput = Omit<
+  InspectionEntry,
+  "id" | "date" | "month" | "createdAt" | "updatedAt"
+> & { month: string }; // exigimos month (lo calculas desde la fecha local)
+
+export async function upsertInspection(date: string, data: InspectionDataInput) {
   const prev = await getByDate(date);
+
   const entry: InspectionEntry = {
     id: prev?.id ?? uid(),
     date,
+    month: data.month,
+
+    // info general
+    movil: data.movil,
+    placas: data.placas,
+    conductorNombre: data.conductorNombre,
+
+    // existentes
     pitoReversa: data.pitoReversa,
     timon: data.timon,
     cinturones: data.cinturones,
     martillos: data.martillos,
     kilometraje: data.kilometraje,
+
+    // nuevas secciones
+    llantasPresion: data.llantasPresion,
+    llantasObjetos: data.llantasObjetos,
+    llantasTuercas: data.llantasTuercas,
+
+    fugasMotor: data.fugasMotor,
+    fugasCaja: data.fugasCaja,
+    fugasDiferencial: data.fugasDiferencial,
+    fugasCombustible: data.fugasCombustible,
+
+    nivelMotor: data.nivelMotor,
+    nivelRefrigerante: data.nivelRefrigerante,
+    nivelHidraulico: data.nivelHidraulico,
+    nivelFrenosEmbrague: data.nivelFrenosEmbrague,
+
+    filtrosEstado: data.filtrosEstado,
+    filtrosFugas: data.filtrosFugas,
+
+    bateriasBornes: data.bateriasBornes,
+    bateriasEstado: data.bateriasEstado,
+
+    correasEstado: data.correasEstado,
+    correasTension: data.correasTension,
+
+    revAseo: data.revAseo,
+    revLucesAltas: data.revLucesAltas,
+    revLucesBajas: data.revLucesBajas,
+    revCocuyos: data.revCocuyos,
+    revLuzBlanca: data.revLuzBlanca,
+
     createdAt: prev?.createdAt ?? Date.now(),
     updatedAt: Date.now(),
   };
+
   await upsertByDate(entry);
   return entry;
 }

--- a/src/shared/services/pdf/templates.ts
+++ b/src/shared/services/pdf/templates.ts
@@ -1,38 +1,332 @@
 import { InspectionEntry } from "@features/inspection/types/InspectionEntry";
 
-const fmt = (b: boolean) => (b ? "Sí" : "No");
+/** Utils de fecha */
+function parseMonth(month: string) {
+  // month: "YYYY-MM"
+  const [y, m] = month.split("-").map(Number);
+  return { y, m }; // m: 1..12
+}
+function daysInMonth(month: string) {
+  const { y, m } = parseMonth(month);
+  return new Date(y, m, 0).getDate(); // último día del mes
+}
+function dayFromISO(iso: string) {
+  // iso: YYYY-MM-DD -> día (1..31)
+  return Number(iso.slice(8, 10));
+}
 
+/** Toma el registro "más representativo" del mes para la tabla general:
+ * preferimos el de mayor updatedAt; si no hay, el de mayor createdAt. */
+function pickLatest(entries: InspectionEntry[]): InspectionEntry | null {
+  if (!entries.length) return null;
+  const sorted = [...entries].sort((a, b) => {
+    const au = a.updatedAt ?? a.createdAt;
+    const bu = b.updatedAt ?? b.createdAt;
+    return bu - au;
+  });
+  return sorted[0];
+}
+
+/** Mapa fecha->entry para accesos O(1) por día */
+function byDayMap(month: string, rows: InspectionEntry[]) {
+  const map = new Map<number, InspectionEntry>();
+  rows.forEach((e) => {
+    if (e.date.startsWith(month + "-")) {
+      map.set(dayFromISO(e.date), e);
+    }
+  });
+  return map;
+}
+
+/** Define filas (ítems) de la matriz con su sección y cómo leer el booleano/valor */
+type RowDef =
+  | { kind: "section"; label: string; align?: "left" | "center" } 
+  | { kind: "bool"; section?: string; label: string; pick: (e: InspectionEntry) => boolean | undefined }
+  | { kind: "number"; section?: string; label: string; pick: (e: InspectionEntry) => number | undefined };
+
+function rowsDefinition(): RowDef[] {
+  const rows: RowDef[] = [
+    { kind: "section", label: "1-ANTES DE LA OPERACIÓN", align: "center"},
+
+    { kind: "section", label: "Interior Vehículo" },
+    { kind: "bool", label: "Pito reversa", pick: (e) => e.pitoReversa },
+    { kind: "bool", label: "Timón", pick: (e) => e.timon },
+    { kind: "bool", label: "Cinturón en cada puesto", pick: (e) => e.cinturones },
+    { kind: "bool", label: "Presencia de martillos", pick: (e) => e.martillos },
+
+    { kind: "number", label: "Kilometraje", pick: (e) => e.kilometraje },
+
+    { kind: "section", label: "Antes de la operación — Llantas" },
+    { kind: "bool", label: "Presión de aire", pick: (e) => e.llantasPresion },
+    { kind: "bool", label: "Objetos incrustados", pick: (e) => e.llantasObjetos },
+    { kind: "bool", label: "Estado de tuercas (completas y ajustadas)", pick: (e) => e.llantasTuercas },
+
+    { kind: "section", label: "Fugas" },
+    { kind: "bool", label: "Motor", pick: (e) => e.fugasMotor },
+    { kind: "bool", label: "Caja", pick: (e) => e.fugasCaja },
+    { kind: "bool", label: "Diferencial", pick: (e) => e.fugasDiferencial },
+    { kind: "bool", label: "Combustible", pick: (e) => e.fugasCombustible },
+
+    { kind: "section", label: "Niveles y tapas" },
+    { kind: "bool", label: "Motor", pick: (e) => e.nivelMotor },
+    { kind: "bool", label: "Agua o refrigerante", pick: (e) => e.nivelRefrigerante },
+    { kind: "bool", label: "Hidráulico", pick: (e) => e.nivelHidraulico },
+    { kind: "bool", label: "Líquido de frenos o embrague", pick: (e) => e.nivelFrenosEmbrague },
+
+    { kind: "section", label: "Filtros" },
+    { kind: "bool", label: "Estado", pick: (e) => e.filtrosEstado },
+    { kind: "bool", label: "Fugas", pick: (e) => e.filtrosFugas },
+
+    { kind: "section", label: "Baterías" },
+    { kind: "bool", label: "Bornes", pick: (e) => e.bateriasBornes },
+    { kind: "bool", label: "Estado general", pick: (e) => e.bateriasEstado },
+
+    { kind: "section", label: "Correas" },
+    { kind: "bool", label: "Estado", pick: (e) => e.correasEstado },
+    { kind: "bool", label: "Tensión", pick: (e) => e.correasTension },
+
+    { kind: "section", label: "Revisión interna" },
+    { kind: "bool", label: "Aseo", pick: (e) => e.revAseo },
+    { kind: "bool", label: "Luces altas", pick: (e) => e.revLucesAltas },
+    { kind: "bool", label: "Luces bajas", pick: (e) => e.revLucesBajas },
+    { kind: "bool", label: "Cocuyos", pick: (e) => e.revCocuyos },
+    { kind: "bool", label: "Luz blanca", pick: (e) => e.revLuzBlanca },
+
+    { kind: "section", label: "2.EN EL MOMENTO DE ENCENDIDO DEL VEHICULO", align: "center" },
+  ];
+  return rows;
+}
+
+/** Render helpers */
+function cellBool(v: boolean | undefined) {
+  if (v === undefined) return "–";
+  return v ? "Sí" : "No";
+}
+function cellNum(v: number | undefined) {
+  if (v === undefined || v === null || Number.isNaN(v)) return "–";
+  return String(v);
+}
+
+/** Tabla de información general (encabezado) */
+function renderGeneralTable(latest: InspectionEntry | null, month: string) {
+  const movil = latest?.movil ?? "";
+  const placas = latest?.placas ?? "";
+  const conductor = latest?.conductorNombre ?? "";
+
+  return `
+  <table class="kv kv-horizontal">
+    <tbody>
+      <tr>
+        <th class="kv-k">MES</th>
+        <td class="kv-v">${escapeHtml(month)}</td>
+        <th class="kv-k">MÓVIL</th>
+        <td class="kv-v">${escapeHtml(movil)}</td>
+        <th class="kv-k">PLACAS</th>
+        <td class="kv-v">${escapeHtml(placas)}</td>
+        <th class="kv-k">CONDUCTOR</th>
+        <td class="kv-v">${escapeHtml(conductor)}</td>
+      </tr>
+    </tbody>
+  </table>`;
+}
+
+
+/** Tabla principal (matriz) */
+function renderMatrixTable(month: string, rows: InspectionEntry[]) {
+  const totalDays = daysInMonth(month);
+  const map = byDayMap(month, rows);
+
+  // colgroup para respetar anchos exactos
+  const colgroup =
+    `<col style="width: var(--item-col)">` +
+    Array.from({ length: totalDays }, () => `<col style="width: var(--day-col)">`).join("");
+
+  // 2ª fila de encabezado: etiqueta "DÍA" + números 1..N
+  const daysHead =
+    '<tr class="days-head">' +
+      '<th class="item-col">DÍA</th>' +
+      Array.from({ length: totalDays }, (_, i) => `<th class="day-col">${i + 1}</th>`).join("") +
+    "</tr>";
+
+  const defs = rowsDefinition();
+  const body = defs.map((def) => {
+    if (def.kind === "section") {
+      // admite centrado si definiste align: "center" en la fila
+      const centerClass = (def as any).align === "center" ? " center" : "";
+      return `<tr class="section${centerClass}">
+                <td class="section-label" colspan="${1 + totalDays}">${escapeHtml(def.label)}</td>
+              </tr>`;
+    }
+    const labelCell = `<td class="item-label">${escapeHtml(def.label)}</td>`;
+    const dayCells = Array.from({ length: totalDays }, (_, idx) => {
+      const day = idx + 1;
+      const entry = map.get(day);
+      if (!entry) return `<td class="day-cell">–</td>`;
+      if (def.kind === "bool") return `<td class="day-cell">${cellBool(def.pick(entry))}</td>`;
+      return `<td class="day-cell num">${cellNum(def.pick(entry))}</td>`;
+    }).join("");
+    return `<tr>${labelCell}${dayCells}</tr>`;
+  }).join("");
+
+  // 1ª fila de encabezado: aviso a conductor a TODO lo ancho
+  const notice =
+    `<tr class="notice">
+       <th class="notice-cell" colspan="${1 + totalDays}">
+         SEÑOR CONDUCTOR: Es importante que se realicen las revisiones diarias recomendadas ANTES, DURANTE y DESPUÉS de la operación.
+         Si encuentra alguna novedad, señalar con una “X” en la casilla correspondiente y relacionarla en la parte posterior de este formato.
+       </th>
+     </tr>`;
+
+  return `
+  <table class="matrix">
+    <colgroup>${colgroup}</colgroup>
+    <thead>
+      ${notice}
+      ${daysHead}
+    </thead>
+    <tbody>${body}</tbody>
+  </table>`;
+}
+
+
+
+/** Pequeño escape para valores de texto */
+function escapeHtml(v: string) {
+  return v
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Estilos: A4 horizontal, tipografía compacta y columnas de días angostas */
+function styles(totalDays: number) {
+  // más días ⇒ columna "Ítem" aún más angosta
+  const itemColMm = totalDays >= 31 ? 62 : totalDays >= 30 ? 66 : 74;
+  const baseFont  = totalDays >= 31 ? 9  : totalDays >= 30 ? 9.2 : 9.5;
+  const scale     = totalDays >= 31 ? 0.86 : totalDays >= 30 ? 0.88 : 0.90;
+
+  return `
+  <style>
+    :root{
+      --page-w: 297mm;
+      --page-h: 210mm;
+      --margin: 8mm;
+
+      --content-w: calc(var(--page-w) - 2 * var(--margin));
+      --days: ${totalDays};
+
+      --item-col: ${itemColMm}mm;
+      --day-col: calc((var(--content-w) - var(--item-col)) / var(--days));
+      --sheet-w: var(--content-w);
+      --scale: ${scale};
+    }
+    @media screen {
+      :root{
+        --content-w: min(95vw, 1350px);
+        --day-col: calc((var(--content-w) - var(--item-col)) / var(--days));
+        --sheet-w: var(--content-w);
+        --scale: 1;
+      }
+    }
+
+    @page { size: A4 landscape; margin: var(--margin); }
+    html, body { height: auto; }
+    body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; font-size: ${baseFont}px; color: #111827; }
+
+    .sheet { width: var(--sheet-w); margin: 0 auto; overflow: hidden; }
+    @media print {
+      .sheet {
+        transform: scale(var(--scale));
+        transform-origin: top left;
+        width: calc(var(--sheet-w) / var(--scale));
+      }
+    }
+
+    h1 { margin: 0 0 6px 0; font-size: 16px; text-align: left; }
+
+    /* Info general (horizontal) */
+    .kv { border-collapse: collapse; margin: 4px 0 8px 0; width: 100%; table-layout: fixed; }
+    .kv th, .kv td { border: 1px solid #e5e7eb; padding: 3px 4px; text-align: left; }
+    .kv.kv-horizontal tbody th { background: #f8fafc; }
+    .kv-k { white-space: nowrap; width: 10%; background: #f3f4f6; }
+    .kv-v { width: 15%; font-weight: 600; }
+
+    /* Matriz: importante border-spacing 0 + table-layout fixed + colgroup */
+    .matrix { border-collapse: collapse; border-spacing: 0; width: 100%; table-layout: fixed; }
+    .matrix th, .matrix td { border: 1px solid #e5e7eb; padding: 2px 2px; }
+    .matrix thead th { background: #f3f4f6; font-weight: 700; }
+    .item-col { width: var(--item-col); text-align: left; }
+    .day-col  { width: var(--day-col); text-align: center; }
+    .item-label { font-weight: 600; }
+    .day-cell { text-align: center; }
+    .day-cell.num { text-align: right; padding-right: 3px; }
+
+    .section .section-label {
+      background: #eef2ff;
+      font-weight: 700;
+      text-align: left;
+      padding: 2px 3px;
+    }
+    .section.center .section-label {
+      text-align: center;
+      background: #e0e7ff;              
+      letter-spacing: .2px;                
+    }
+    
+    .notice .notice-cell {
+      background: #fff7ed;         
+      border: 1px solid #e5e7eb;
+      font-weight: 600;
+      text-align: left;
+      padding: 6px 8px;
+      line-height: 1.25;
+    }
+    
+    /* Encabezado de días (debajo del aviso) */
+    .days-head th {
+      background: #f3f4f6;
+      border: 1px solid #e5e7eb;
+      padding: 2px 3px;
+      font-weight: 700;
+      text-align: center;
+    }
+    .days-head th.item-col { text-align: center; } /* “DÍA” alineado a la izquierda */
+
+    /* Secciones centradas opcionales (si usaste align: "center") */
+    .section.center .section-label {
+      text-align: center;
+      background: #e0e7ff;
+      letter-spacing: .2px;
+    }
+
+    th, td { word-wrap: break-word; overflow-wrap: anywhere; }
+  </style>`;
+}
+
+
+/** HTML principal del PDF mensual */
 export function buildMonthlyHtml(month: string, rows: InspectionEntry[]) {
-  const items = rows.map(r => `
-    <tr>
-      <td>${r.date}</td>
-      <td>${fmt(r.pitoReversa)}</td>
-      <td>${fmt(r.timon)}</td>
-      <td>${fmt(r.cinturones)}</td>
-      <td>${fmt(r.martillos)}</td>
-      <td style="text-align:right">${r.kilometraje}</td>
-    </tr>`).join("");
+  const latest = pickLatest(rows);
+  const totalDays = daysInMonth(month);
 
-  return `<!doctype html><html><head><meta charset="utf-8"/>
+  return `
+  <!doctype html>
+  <html>
+  <head>
+    <meta charset="utf-8"/>
     <title>RutaCheck ${month}</title>
-    <style>
-      body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 24px; }
-      h1 { margin: 0 0 12px 0; }
-      table { border-collapse: collapse; width: 100%; }
-      th, td { border: 1px solid #e5e7eb; padding: 8px; font-size: 12px; }
-      th { background: #f3f4f6; text-align: left; }
-    </style>
+    ${styles(totalDays)}
   </head>
   <body>
-    <h1>RutaCheck — ${month}</h1>
-    <table>
-      <thead>
-        <tr>
-          <th>Fecha</th><th>Pito reversa</th><th>Timón</th>
-          <th>Cinturones</th><th>Martillos</th><th style="text-align:right">Kilometraje</th>
-        </tr>
-      </thead>
-      <tbody>${items || `<tr><td colspan="6">Sin registros</td></tr>`}</tbody>
-    </table>
-  </body></html>`;
+    <div class="sheet">
+      <h1>RutaCheck — ${month}</h1>
+
+      ${renderGeneralTable(latest, month)}
+
+      ${renderMatrixTable(month, rows)}
+    </div>
+  </body>
+  </html>`;
 }
+


### PR DESCRIPTION
- Implement monthly PDF as a matrix: rows = checklist items, columns = month days (1..N)
- Add horizontal "General info" header row (MONTH, MOBILE, PLATES, DRIVER)
- Introduce driver notice band above the days header, unified within the same table grid
- Add centered section row "1-ANTES DE LA OPERACIÓN" before "Interior Vehículo"
- Use <colgroup> + CSS variables to enforce exact column widths
- A4 landscape layout in mm; adaptive item column width and day column calculation
- Compact typography/paddings + print scaling to fit 30/31 days on a single page
- Local date helpers (todayLocalISO, monthLocalISO) to avoid UTC off-by-one
- HomeScreen/FormScreen updated to use local dates consistently
- Escape HTML safely for WebView compatibility
