### PR TITLE
feat(profile): add vehicle/driver settings screen and wire PDF to profile data- Add Profile screen to edit persistent fields: mobile number (móvil), plates and driver name

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout() {
       {/* Rutas fuera de tabs */}
       <Stack.Screen name="form/index"  options={{ title: "Formulario" }} />
       <Stack.Screen name="saved/index" options={{ title: "Info guardada" }} />
+      <Stack.Screen name="profile/index" options={{ title: "Datos del vehículo" }} />
     </Stack>
   );
 }

--- a/app/profile/index.tsx
+++ b/app/profile/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "@features/profile/screens/ProfileScreen";

--- a/src/features/inspection/screens/FormScreen.tsx
+++ b/src/features/inspection/screens/FormScreen.tsx
@@ -16,11 +16,6 @@ export default function FormScreen() {
 
   const [loading, setLoading] = useState(true);
 
-  // --- Información general ---
-  const [movil, setMovil] = useState("");
-  const [placas, setPlacas] = useState("");
-  const [conductorNombre, setConductorNombre] = useState("");
-
   // --- (lo que ya tenías) Interior Vehículo ---
   const [pitoReversa, setPitoReversa] = useState(false);
   const [timon, setTimon] = useState(false);
@@ -63,11 +58,6 @@ export default function FormScreen() {
     (async () => {
       const existing = await getByDate(date);
       if (existing) {
-        // General
-        setMovil(existing.movil ?? "");
-        setPlacas(existing.placas ?? "");
-        setConductorNombre(existing.conductorNombre ?? "");
-
         // Interior
         setPitoReversa(existing.pitoReversa);
         setTimon(existing.timon);
@@ -119,9 +109,6 @@ export default function FormScreen() {
     await upsertInspection(date, {
       month, // <- se guarda mes local YYYY-MM
 
-      // General
-      movil, placas, conductorNombre,
-
       // Interior existente
       pitoReversa, timon, cinturones: cinturon, martillos, kilometraje: kmNum,
 
@@ -150,16 +137,6 @@ export default function FormScreen() {
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Formulario del día</Text>
       <Text style={styles.subtitle}>{toLocalISO(new Date(date))}</Text>
-
-      {/* Información general */}
-      <View style={styles.card}>
-        <Text style={styles.sectionTitle}>Información general</Text>
-
-        <LabeledInput label="Mes" value={month} editable={false} />
-        <LabeledInput label="Móvil" value={movil} onChangeText={setMovil} />
-        <LabeledInput label="Placas" value={placas} onChangeText={setPlacas} autoCapitalize="characters" />
-        <LabeledInput label="Nombre del conductor" value={conductorNombre} onChangeText={setConductorNombre} />
-      </View>
 
       {/* Interior vehículo (lo previo) */}
       <Pressable style={styles.card}>

--- a/src/features/inspection/screens/HomeScreen.tsx
+++ b/src/features/inspection/screens/HomeScreen.tsx
@@ -44,6 +44,7 @@ export default function HomeScreen() {
         onPress={goToForm}
         variant="primary"
       />
+      <Button title="Datos del vehículo y conductor" onPress={() => router.push("/profile")} />
       <Button title="Ver info guardada" onPress={() => router.push("/saved")} variant="secondary" />
       <Button title="Generar PDF (mes actual)" onPress={handleGeneratePdf} variant="success" />
     </Screen>

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "@features/profile/screens/ProfileScreen";

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { View, Text, StyleSheet, TextInput, Alert } from "react-native";
+import Screen from "@shared/components/Screen";
+import Button from "@shared/components/Button";
+import { getProfile, saveProfile } from "@features/profile/services/profileStorage";
+
+export default function ProfileScreen() {
+  const [movil, setMovil] = useState("");
+  const [placas, setPlacas] = useState("");
+  const [conductorNombre, setConductorNombre] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const p = await getProfile();
+      if (p) {
+        setMovil(p.movil ?? "");
+        setPlacas(p.placas ?? "");
+        setConductorNombre(p.conductorNombre ?? "");
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const onSave = async () => {
+    if (!movil.trim() || !placas.trim() || !conductorNombre.trim()) {
+      Alert.alert("Datos requeridos", "Completa todos los campos.");
+      return;
+    }
+    await saveProfile({ movil: movil.trim(), placas: placas.trim(), conductorNombre: conductorNombre.trim() });
+    Alert.alert("Guardado", "Datos actualizados correctamente.");
+  };
+
+  if (loading) return <Screen />;
+
+  return (
+    <Screen style={styles.container}>
+      <Text style={styles.title}>Datos del vehículo y conductor</Text>
+
+      <Field label="Móvil">
+        <TextInput style={styles.input} value={movil} onChangeText={setMovil} />
+      </Field>
+
+      <Field label="Placas">
+        <TextInput style={styles.input} value={placas} onChangeText={setPlacas} autoCapitalize="characters" />
+      </Field>
+
+      <Field label="Nombre del conductor">
+        <TextInput style={styles.input} value={conductorNombre} onChangeText={setConductorNombre} />
+      </Field>
+
+      <Button title="Guardar" onPress={onSave} />
+    </Screen>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, gap: 12 },
+  title: { fontSize: 20, fontWeight: "700", marginBottom: 8 },
+  field: { gap: 6 },
+  label: { fontWeight: "600" },
+  input: {
+    borderWidth: 1, borderColor: "#e5e7eb", borderRadius: 10,
+    paddingHorizontal: 12, paddingVertical: 10, backgroundColor: "#fff",
+  },
+});

--- a/src/features/profile/services/profileStorage.ts
+++ b/src/features/profile/services/profileStorage.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { UserProfile } from "../types/UserProfile";
+
+const KEY = "rutacheck:user-profile";
+
+export async function getProfile(): Promise<UserProfile | null> {
+  const raw = await AsyncStorage.getItem(KEY);
+  return raw ? (JSON.parse(raw) as UserProfile) : null;
+}
+
+export async function saveProfile(p: Omit<UserProfile, "updatedAt">) {
+  const data: UserProfile = { ...p, updatedAt: Date.now() };
+  await AsyncStorage.setItem(KEY, JSON.stringify(data));
+  return data;
+}

--- a/src/features/profile/types/UserProfile.ts
+++ b/src/features/profile/types/UserProfile.ts
@@ -1,0 +1,6 @@
+export type UserProfile = {
+    movil: string,
+    placas: string,
+    conductorNombre: string,
+    updatedAt: number,
+};

--- a/src/shared/services/pdf/monthlyPdf.ts
+++ b/src/shared/services/pdf/monthlyPdf.ts
@@ -2,13 +2,15 @@ import * as Print from "expo-print";
 import * as Sharing from "expo-sharing";
 import { Platform, Alert } from "react-native";
 import { getEntriesOfMonth } from "@features/inspection/usecases/getMonthlyReport";
+import { getProfile } from "@features/profile/services/profileStorage";
 import { buildMonthlyHtml } from "./templates";
 
 export async function generateMonthlyPdf(month: string) {
   const rows = await getEntriesOfMonth(month);
   if (rows.length === 0) throw new Error("No hay datos guardados para este mes.");
-
-  const html = buildMonthlyHtml(month, rows);
+  const profile = await getProfile();
+  
+  const html = buildMonthlyHtml(month, rows, profile);
 
   if (Platform.OS === "web") {
     const w = window.open("", "_blank");

--- a/src/shared/services/pdf/templates.ts
+++ b/src/shared/services/pdf/templates.ts
@@ -1,4 +1,5 @@
 import { InspectionEntry } from "@features/inspection/types/InspectionEntry";
+import { UserProfile } from "@features/profile/types/UserProfile";
 
 /** Utils de fecha */
 function parseMonth(month: string) {
@@ -108,10 +109,10 @@ function cellNum(v: number | undefined) {
 }
 
 /** Tabla de información general (encabezado) */
-function renderGeneralTable(latest: InspectionEntry | null, month: string) {
-  const movil = latest?.movil ?? "";
-  const placas = latest?.placas ?? "";
-  const conductor = latest?.conductorNombre ?? "";
+function renderGeneralTable(profile: UserProfile | null, month: string) {
+  const movil = profile?.movil ?? "";
+  const placas = profile?.placas ?? "";
+  const conductor = profile?.conductorNombre ?? "";
 
   return `
   <table class="kv kv-horizontal">
@@ -306,8 +307,7 @@ function styles(totalDays: number) {
 
 
 /** HTML principal del PDF mensual */
-export function buildMonthlyHtml(month: string, rows: InspectionEntry[]) {
-  const latest = pickLatest(rows);
+export function buildMonthlyHtml(month: string, rows: InspectionEntry[], profile: UserProfile | null) {
   const totalDays = daysInMonth(month);
 
   return `
@@ -322,7 +322,7 @@ export function buildMonthlyHtml(month: string, rows: InspectionEntry[]) {
     <div class="sheet">
       <h1>RutaCheck — ${month}</h1>
 
-      ${renderGeneralTable(latest, month)}
+      ${renderGeneralTable(profile, month)}
 
       ${renderMatrixTable(month, rows)}
     </div>


### PR DESCRIPTION
- Persist profile via AsyncStorage (getProfile/saveProfile) as transversal app data
- Add Home button to open Profile screen
- Remove vehicle/driver fields from daily form (no longer filled every day)
- Update monthly PDF to read general info from profile instead of last entry
- Keep daily form and storage unchanged for operational checks
- Add /profile route and navigation; align routes with expo-router types