### PR TITLE
fix(date): avoid UTC shift by parsing YYYY-MM-DD as local date

### DIFF
--- a/src/features/inspection/screens/FormScreen.tsx
+++ b/src/features/inspection/screens/FormScreen.tsx
@@ -4,15 +4,14 @@ import { useLocalSearchParams, router } from "expo-router";
 import Screen from "@shared/components/Screen";
 import Button from "@shared/components/Button";
 import BoolField from "@features/inspection/components/BoolField";
-import KmInput from "@features/inspection/components/KmInput";
 import { getByDate } from "@features/inspection/services/inspectionStorage";
 import { upsertInspection } from "@features/inspection/usecases/upsertEntry";
-import { monthLocalISO, toLocalISO } from "@shared/utils/date";
+import { todayLocalISO, monthFromYmd } from "@shared/utils/date";
 
 export default function FormScreen() {
   const params = useLocalSearchParams<{ date?: string }>();
-  const date = params.date ? String(params.date) : toLocalISO(new Date());
-  const month = monthLocalISO(new Date(date as string)); // YYYY-MM local
+const date = params.date ? String(params.date) : todayLocalISO();
+const month = monthFromYmd(date); // solo corta "YYYY-MM"
 
   const [loading, setLoading] = useState(true);
 
@@ -86,7 +85,7 @@ export default function FormScreen() {
   }, [date]);
 
   const handleGuardar = async () => {
-    
+
     await upsertInspection(date, {
       month, // <- se guarda mes local YYYY-MM
 
@@ -114,7 +113,7 @@ export default function FormScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Formulario del día</Text>
-      <Text style={styles.subtitle}>{toLocalISO(new Date(date))}</Text>
+      <Text style={styles.subtitle}>{date}</Text>
 
       {/* Antes de la operación */}
       <Pressable style={styles.card}>

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -1,11 +1,11 @@
-// YYYY-MM-DD en HORA LOCAL (no UTC)
+// Fecha local de "hoy" -> "YYYY-MM-DD"
 export function todayLocalISO(): string {
   const d = new Date();
-  // truco: compensa el timezone para que toISOString no salte de día
-  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
-  return d.toISOString().slice(0, 10);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
-
 // Convierte un Date cualquiera a YYYY-MM-DD local
 export function toLocalISO(date: Date): string {
   const d = new Date(date);
@@ -19,3 +19,15 @@ export function monthLocalISO(date: Date = new Date()): string {
   d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
   return d.toISOString().slice(0, 7);
 }
+
+// Convierte "YYYY-MM-DD" a Date local (¡no UTC!)
+export function ymdToLocalDate(ymd: string): Date {
+  const [y, m, d] = ymd.split("-").map(Number);
+  return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+// Mes desde "YYYY-MM" o "YYYY-MM-DD"
+export function monthFromYmd(ymdOrMonth: string): string {
+  return ymdOrMonth.slice(0, 7);
+}
+


### PR DESCRIPTION
- Replace new Date("YYYY-MM-DD") with safe local helpers
- Add todayLocalISO, ymdToLocalDate, monthFromYmd utilities
- Update FormScreen/HomeScreen to use local YMD strings
- Prevent off-by-one day in Colombia (UTC-5) and other timezones
